### PR TITLE
Support both newline and space separated list of repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@
       my-org/third-action
 ```
 
+Space separated lists work too. Very useful when retrieving the list with another step and chaining things.
+
+```yaml
+- uses: actions/checkout@v2
+- name: Checkout private actions
+  uses: vweevers/multi-checkout-action@v1
+  with:
+    token: ${{ secrets.GITHUB_MACHINE_TOKEN }}
+    repositories: my-org/example-action my-org/another-action@v3.1.0 my-org/third-action
+```
+
 The private actions can then be used like so:
 
 ```yaml
@@ -30,7 +41,7 @@ The token must have read access to the repositories. In the case of private repo
 
 ## Inputs
 
-- `repositories`: newline-separated repositories in the form of `owner/name` (to checkout the default branch) or `owner/name@ref` where `ref` is a branch name, tag or SHA to checkout.
+- `repositories`: newline-or-space-separated repositories in the form of `owner/name` (to checkout the default branch) or `owner/name@ref` where `ref` is a branch name, tag or SHA to checkout.
 - `path`: relative path under `$GITHUB_WORKSPACE` to place the repositories. Default is `..` so that repositories are cloned to `../owner/name`.
 
 Other inputs are forwarded to [`actions/checkout`](https://github.com/actions/checkout) (excluding `repository`, `ref` and `persist-credentials` which is always `false`).

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const fsp = require('fs').promises
 const path = require('path')
 
 async function main () {
-  const items = (process.env.INPUT_REPOSITORIES || '').split(/[\s]+/).filter(Boolean)
+  const items = (process.env.INPUT_REPOSITORIES || '').split(/\s+/).filter(Boolean)
   const workspace = path.resolve(process.env.GITHUB_WORKSPACE || '.')
   const basedir = path.resolve(workspace, process.env.INPUT_PATH || '..')
   const env = {}

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const fsp = require('fs').promises
 const path = require('path')
 
 async function main () {
-  const items = (process.env.INPUT_REPOSITORIES || '').split(/[\r\n]+/).filter(Boolean)
+  const items = (process.env.INPUT_REPOSITORIES || '').split(/[\s]+/).filter(Boolean)
   const workspace = path.resolve(process.env.GITHUB_WORKSPACE || '.')
   const basedir = path.resolve(workspace, process.env.INPUT_PATH || '..')
   const env = {}


### PR DESCRIPTION
When trying to chain this with another step to retrieve a list of repositories from a json file for example, it's pretty hard to convert it back to a newline separated list as it has to go through the bash engine with a sanitized json representation before.

This will make it much easier without breaking the current functionality.