### PR TITLE
Deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Deprecation Notice
 
-**This action is deprecated and will be unpublished in 2025.** I originally wrote it to use actions from private repositories. GitHub has sinced implemented a [a built-in way](https://docs.github.com/en/actions/creating-actions/sharing-actions-and-workflows-from-your-private-repository) to share such actions, removing the need for `multi-checkout-action`.
+**This action is deprecated and will be unpublished in 2025.** I originally wrote it to use actions from private repositories. GitHub has since implemented [a built-in way](https://docs.github.com/en/actions/creating-actions/sharing-actions-and-workflows-from-your-private-repository) to share such actions, removing the need for `multi-checkout-action`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # multi-checkout-action
 
-**A [GitHub Action](https://github.com/features/actions) that wraps [`actions/checkout`](https://github.com/actions/checkout) to checkout multiple additional repositories.**
+**A [GitHub Action](https://github.com/features/actions) that wraps [`actions/checkout`](https://github.com/actions/checkout) to checkout multiple additional repositories.** 
 
 ![GitHub tag](https://img.shields.io/github/v/tag/vweevers/multi-checkout-action?sort=semver)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+
+## Deprecation Notice
+
+**This action is deprecated and will be unpublished in 2025.** I originally wrote it to use actions from private repositories. GitHub has sinced implemented a [a built-in way](https://docs.github.com/en/actions/creating-actions/sharing-actions-and-workflows-from-your-private-repository) to share such actions, removing the need for `multi-checkout-action`.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const fsp = require('fs').promises
 const path = require('path')
 
 async function main () {
+  console.log('::warning title=multi-checkout-action::The vweevers/multi-checkout-action action is deprecated and will be unpublished in 2025.')
+
   const items = (process.env.INPUT_REPOSITORIES || '').split(/\s+/).filter(Boolean)
   const workspace = path.resolve(process.env.GITHUB_WORKSPACE || '.')
   const basedir = path.resolve(workspace, process.env.INPUT_PATH || '..')


### PR DESCRIPTION
I originally wrote this to use actions from private repositories. GitHub has since implemented [a built-in way](https://docs.github.com/en/actions/creating-actions/sharing-actions-and-workflows-from-your-private-repository) to share such actions, removing the need for `multi-checkout-action`.